### PR TITLE
Make strict comparisons

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -39,7 +39,7 @@ abstract class Enum
 
     public static function has($string): bool
     {
-        return static::all()->contains($string);
+        return static::all()->containsStrict($string);
     }
 
     public static function required()

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\TestCase;
 use SjorsO\Enum\Enum;
+use SjorsO\Enum\Tests\Examples\NumericEnum;
 use SjorsO\Enum\Tests\Examples\UserRole;
 
 class EnumTest extends TestCase
@@ -111,5 +112,23 @@ class EnumTest extends TestCase
         $this->userRole::assert('role_unknown');
 
         $this->fail('Excepted a RunTimeException to be thrown');
+    }
+
+    /** @test */
+    function enum_has_is_strict()
+    {
+        $this->assertTrue(NumericEnum::has(0));
+        $this->assertFalse(NumericEnum::has('0'));
+        $this->assertFalse(NumericEnum::has(null));
+        $this->assertFalse(NumericEnum::has(false));
+
+        $this->assertTrue(NumericEnum::has(1));
+        $this->assertFalse(NumericEnum::has('1'));
+        $this->assertFalse(NumericEnum::has(true));
+
+        $this->assertFalse(NumericEnum::has(2)); // 2 is protected
+        $this->assertFalse(NumericEnum::has('2')); // 2 is protected
+        $this->assertFalse(NumericEnum::has(3)); // 3 is private
+        $this->assertFalse(NumericEnum::has('3')); // 3 is private
     }
 }

--- a/tests/Examples/NumericEnum.php
+++ b/tests/Examples/NumericEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SjorsO\Enum\Tests\Examples;
+
+use SjorsO\Enum\Enum;
+
+class NumericEnum extends Enum
+{
+    const ZERO = 0;
+
+    const ONE = 1;
+
+    protected const NOT_THIS_ONE = 2;
+
+    private const ALSO_NOT_THIS_ONE = 3;
+}


### PR DESCRIPTION
This fixes the following problem:

```php
class Roles extends Enum
{
    const ADMIN = 0;
}

// before
Roles::has(null) === true

// after
Roles::has(null) === false
```
